### PR TITLE
Audio normalize

### DIFF
--- a/audio_processor.py
+++ b/audio_processor.py
@@ -1,9 +1,10 @@
 from pydub import AudioSegment
 import numpy as np
 import scipy.signal as signal
+import matplotlib.pyplot as plt
 import warnings
 
-def mp3_to_amplitude_series(mp3_file_path: str, channels: str='left', start_time: float = 0.0, duration: float = 1e9) -> tuple[np.ndarray, float, float, int]:
+def mp3_to_amplitude_series(mp3_file_path: str, channels: str='left', start_time: float = 0.0, duration: float = 1e9, target_volume: float = -10.0) -> tuple[np.ndarray, float, float, int]:
     """
     Load an MP3 file and convert it to a numpy array of amplitude values.
     
@@ -15,6 +16,7 @@ def mp3_to_amplitude_series(mp3_file_path: str, channels: str='left', start_time
     """
     # Load the MP3 file
     audio = AudioSegment.from_mp3(mp3_file_path)
+    audio = match_target_amplitude(audio, target_volume)
     
     # Convert the audio to raw data
     raw_data = audio.raw_data
@@ -96,7 +98,8 @@ def export_to_mp3(amplitude_series: np.ndarray, frame_rate: float, sample_width:
     :param output_file_path: The path to save the output MP3 file.
     """
     # Denormalize the voltage series to integer values (assuming 16-bit audio)
-    audio_data = (amplitude_series * (2**(8 * sample_width - 1))).astype(np.int16)
+    audio_data = np.array(amplitude_series * (2**(8 * sample_width - 1)))
+    audio_data = audio_data.astype(np.int16)
     
     # If the audio has more than one channel, reshape the array
     if num_channels > 1:
@@ -127,34 +130,52 @@ def add_silent_start(amplitude_series: np.ndarray, frame_rate: float, duration: 
     silent_start = np.zeros(num_samples)
     return np.concatenate([silent_start, amplitude_series])
 
+def match_target_amplitude(audio: AudioSegment, target_dBFS: float) -> AudioSegment:
+    '''
+    Match the target amplitude of the audio segment to the specified dBFS level.
+
+    :param audio: The audio segment to modify.
+    :param target_dBFS: The target dBFS level to achieve.
+    :return: The modified audio segment.
+    '''
+    change_in_dBFS = target_dBFS - audio.dBFS
+    return audio.apply_gain(change_in_dBFS)
+
+def plot_amplitude_series(amplitude_series: np.ndarray, frame_rate: float) -> None:
+    """
+    Plot the amplitude series over time.
+
+    :param amplitude_series: A numpy array of audio amplitude values.
+    :param frame_rate: The frame rate of the audio.
+    :param max_amplitude: The maximum amplitude value for normalization.
+    """
+    time = np.arange(len(amplitude_series)) / frame_rate
+    plt.figure(figsize=(12, 6))
+    plt.plot(time, amplitude_series, color='r', label='Audio signal')
+    plt.ylim(-1.1, 1.1)
+    plt.hlines([-1, 1], 0, time[-1], colors='black', linestyles='dashed', label='Max amplitude')
+    plt.xlabel('Time [s]')
+    plt.ylabel('Amplitude [ ]')
+    plt.title('Audio Amplitude vs Time')
+    plt.legend()
+    plt.grid()
+    plt.show()
+
+
 # Example usage
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
-
     path = './audio_files/'
-    input_file = 'michel.mp3'
-    cutoff_freq = 500 # Hz
+    input_file = 'english.mp3'
+    cutoff_freq = 3000 # Hz
 
     # Convert mp3 to filtered amplitude signal
-    amplitudes, frame_rate, sample_width, num_channels = mp3_to_amplitude_series(path+input_file, channels='left', start_time=15.5)
+    amplitudes, frame_rate, sample_width, num_channels = mp3_to_amplitude_series(path+input_file, channels='left', start_time=0, duration=5, target_volume=-18.0)
     amplitudes_filtered = apply_low_pass_filter(amplitudes, frame_rate, cutoff_freq=cutoff_freq)
 
+    # Plot the amplitude series
+    plot_amplitude_series(amplitudes, frame_rate)
+    
     # Export the filtered signal to an MP3 file
-    output_file = path + 'filtered/' + input_file.split('.')[0] + f'_filtered_{int(cutoff_freq)}Hz.mp3'
-    export_to_mp3(amplitudes_filtered, frame_rate, sample_width, num_channels, output_file)
-
-    # # Plot the amplitude against time
-    # time = np.arange(len(voltage_series)) / frame_rate
-    # plot_window = int(10 * frame_rate) # Plot only the first X second
-
-    # plt.figure(figsize=(12, 6))
-    # plt.plot(time[10*frame_rate:10*frame_rate+plot_window], voltage_series[10*frame_rate:10*frame_rate+plot_window,0], label='Raw')
-    # plt.plot(time[10*frame_rate:10*frame_rate+plot_window], voltage_series_7k[10*frame_rate:10*frame_rate+plot_window], label='Filtered 7 kHz')
-    # plt.plot(time[10*frame_rate:10*frame_rate+plot_window], voltage_series_3k[10*frame_rate:10*frame_rate+plot_window], label='Filtered 3 kHz')
-    # plt.xlabel('Time (seconds)')
-    # plt.ylabel('Amplitude')
-    # plt.title('Audio Amplitude vs Time')
-    # plt.legend()
-    # plt.grid()
-    # plt.show()
+    # output_file = path + 'filtered/' + input_file.split('.')[0] + f'_filtered_{int(cutoff_freq)}Hz.mp3'
+    # export_to_mp3(amplitudes_filtered, frame_rate, sample_width, num_channels, output_file)
 

--- a/audio_processor.py
+++ b/audio_processor.py
@@ -98,8 +98,7 @@ def export_to_mp3(amplitude_series: np.ndarray, frame_rate: float, sample_width:
     :param output_file_path: The path to save the output MP3 file.
     """
     # Denormalize the voltage series to integer values (assuming 16-bit audio)
-    audio_data = np.array(amplitude_series * (2**(8 * sample_width - 1)))
-    audio_data = audio_data.astype(np.int16)
+    audio_data = np.array(amplitude_series * (2**(8 * sample_width - 1))).astype(np.int16)
     
     # If the audio has more than one channel, reshape the array
     if num_channels > 1:
@@ -165,17 +164,17 @@ def plot_amplitude_series(amplitude_series: np.ndarray, frame_rate: float) -> No
 # Example usage
 if __name__ == "__main__":
     path = './audio_files/'
-    input_file = 'english.mp3'
+    input_file = 'scale_cdef.mp3'
     cutoff_freq = 3000 # Hz
 
     # Convert mp3 to filtered amplitude signal
-    amplitudes, frame_rate, sample_width, num_channels = mp3_to_amplitude_series(path+input_file, channels='left', start_time=0, duration=5, target_volume=-18.0)
-    amplitudes_filtered = apply_low_pass_filter(amplitudes, frame_rate, cutoff_freq=cutoff_freq)
+    amplitudes, frame_rate, sample_width, num_channels = mp3_to_amplitude_series(path+input_file, channels='left', start_time=0, target_volume=-18.0)
+    amplitudes_filtered, frame_rate = apply_low_pass_filter(amplitudes, frame_rate, cutoff_freq=cutoff_freq)
 
     # Plot the amplitude series
     plot_amplitude_series(amplitudes, frame_rate)
     
     # Export the filtered signal to an MP3 file
-    # output_file = path + 'filtered/' + input_file.split('.')[0] + f'_filtered_{int(cutoff_freq)}Hz.mp3'
-    # export_to_mp3(amplitudes_filtered, frame_rate, sample_width, num_channels, output_file)
+    output_file = path + 'filtered/' + input_file.split('.')[0] + f'_filtered_{int(cutoff_freq)}Hz.mp3'
+    export_to_mp3(amplitudes_filtered, frame_rate, sample_width, num_channels, output_file)
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from parameters import default_parameters as p
 # Usage
 if __name__ == "__main__":
     # Extract amplitudes from audio
-    amplitudes, frame_rate, *_ = ap.mp3_to_amplitude_series(p.input_folder+p.input_filename, channels='left', start_time=p.start_time, duration=p.duration)
+    amplitudes, frame_rate, *_ = ap.mp3_to_amplitude_series(p.input_folder+p.input_filename, channels='left', start_time=p.start_time, duration=p.duration, target_volume=p.target_volume)
     if p.filter_active:
         amplitudes, frame_rate = ap.apply_low_pass_filter(amplitudes, frame_rate, cutoff_freq=p.cutoff_freq, downsample=True)
 

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
     amplitudes, frame_rate, *_ = ap.mp3_to_amplitude_series(p.input_folder+p.input_filename, channels='left', start_time=p.start_time, duration=p.duration, target_volume=p.target_volume)
     if p.filter_active:
         amplitudes, frame_rate = ap.apply_low_pass_filter(amplitudes, frame_rate, cutoff_freq=p.cutoff_freq, downsample=True)
+    ap.plot_amplitude_series(amplitudes, frame_rate)
 
     amplitudes = ap.add_silent_start(amplitudes, frame_rate, duration=p.silent_start_duration)
 

--- a/parameters.py
+++ b/parameters.py
@@ -35,6 +35,7 @@ class ParameterSet:
     start_time:             float = attrs.field(default=0) # How many seconds to crop from the start of the audio
     duration:               float = attrs.field(default=3.0) # Duration of the audio signal [s]
     silent_start_duration:  float = attrs.field(default=0.5) # Duration of the silent start [s]
+    target_volume:          float = attrs.field(default=-18.0) # Target amplitude for the sound [dBFS]. In Europe, the EBU recommend that −18 dBFS equates to the alignment level.
 
     # Image
     pixel_size:             float = attrs.field(default=0.01) # Size of a pixel in the image [mm]


### PR DESCRIPTION
This pull request adds new functionality for amplitude normalization and visualization to the audio processing workflow, and introduces a configurable target volume parameter. The changes improve reproducibility of audio output and make it easier to inspect audio signals visually. The most important changes are grouped below.

**Amplitude Normalization and Target Volume Support**

* Added a `target_volume` parameter (in dBFS) to the `mp3_to_amplitude_series` function in `audio_processor.py`, allowing users to specify the desired loudness level for processed audio. The `ParameterSet` class in `parameters.py` also now includes this parameter for easy configuration. [[1]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cR4-R7) [[2]](diffhunk://#diff-89b986fb120d6829b663b7fcfc98a5b7a4326150cf058c4a8695c4982721a623R38)
* Implemented the `match_target_amplitude` function in `audio_processor.py` to adjust the audio segment's gain so that its amplitude matches the specified target dBFS level. This is now applied automatically in the audio extraction workflow. [[1]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cR19) [[2]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cR132-L160)

**Audio Visualization**

* Added a `plot_amplitude_series` function in `audio_processor.py` that plots the amplitude of the audio signal over time using matplotlib, making it easier to visually inspect the waveform. This function is now called in both `audio_processor.py` and `main.py` after amplitude extraction. [[1]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cR132-L160) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L9-R12)

**Minor Improvements**

* Updated the example usage and main workflow to use the new target volume and plotting features, and made minor fixes to audio data handling for exporting MP3 files. [[1]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cL99-R101) [[2]](diffhunk://#diff-2d5380d727635e4b1874d88c6ef1bf79c4668ae949414d3716c348898856ba6cR132-L160) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L9-R12)